### PR TITLE
Добавить опцию `linesearch` к точке входа для PARAFAC

### DIFF
--- a/R/parafac.R
+++ b/R/parafac.R
@@ -5,7 +5,7 @@ parafac <-
            Astruc = NULL, Bstruc = NULL, Cstruc = NULL, Dstruc = NULL,
            Amodes = NULL, Bmodes = NULL, Cmodes = NULL, Dmodes = NULL,
            maxit = 500, ctol = 1e-4, parallel = FALSE, cl = NULL, 
-           output = c("best", "all"), verbose = TRUE, backfit = FALSE,usels = FALSE){
+           output = c("best", "all"), verbose = TRUE, backfit = FALSE,linesearch = NULL){
     # 3-way or 4-way Parallel Factor Analysis (Parafac)
     # via alternating least squares (ALS) with optional constraints
     # Nathaniel E. Helwig (helwig@umn.edu)
@@ -181,7 +181,7 @@ parafac <-
                                 Astart = Astart, Bstart = Bstart, Cstart = Cstart,
                                 Astruc = Astruc, Bstruc = Bstruc, Cstruc = Cstruc,
                                 Amodes = Amodes, Bmodes = Bmodes, Cmodes = Cmodes,
-                                backfit = backfit)
+                                backfit = backfit, linesearch = linesearch)
         } else {
           pfaclist <- parLapply(cl = cl, X = nstartlist, fun = "parafac_3way",
                                 data = X, xcx = xcx, const = const,
@@ -204,7 +204,7 @@ parafac <-
                                    Astart = Astart, Bstart = Bstart, Cstart = Cstart,
                                    Astruc = Astruc, Bstruc = Bstruc, Cstruc = Cstruc,
                                    Amodes = Amodes, Bmodes = Bmodes, Cmodes = Cmodes,
-                                   backfit = backfit)
+                                   backfit = backfit, linesearch = linesearch)
             if(verbose) setTxtProgressBar(pbar, 1)
             if(nstart > 1L){
               for(j in 2:nstart){
@@ -214,7 +214,7 @@ parafac <-
                                        Astart = Astart, Bstart = Bstart, Cstart = Cstart,
                                        Astruc = Astruc, Bstruc = Bstruc, Cstruc = Cstruc,
                                        Amodes = Amodes, Bmodes = Bmodes, Cmodes = Cmodes,
-                                       backfit = backfit)
+                                       backfit = backfit, linesearch = linesearch)
                 if(pnew$SSE < pfac$SSE) pfac <- pnew
                 if(verbose) setTxtProgressBar(pbar, j)
               } # end for(j in 2:nstart)
@@ -254,7 +254,7 @@ parafac <-
                                               Astart = Astart, Bstart = Bstart, Cstart = Cstart,
                                               Astruc = Astruc, Bstruc = Bstruc, Cstruc = Cstruc,
                                               Amodes = Amodes, Bmodes = Bmodes, Cmodes = Cmodes,
-                                              backfit = backfit)
+                                              backfit = backfit, linesearch = linesearch)
               if(verbose) setTxtProgressBar(pbar, j)
             }
           } else {

--- a/man/parafac.Rd
+++ b/man/parafac.Rd
@@ -13,7 +13,8 @@ parafac(X, nfac, nstart = 10, const = NULL, control = NULL,
         Astruc = NULL, Bstruc = NULL, Cstruc = NULL, Dstruc = NULL,
         Amodes = NULL, Bmodes = NULL, Cmodes = NULL, Dmodes = NULL,
         maxit = 500, ctol = 1e-4, parallel = FALSE, cl = NULL,
-        output = c("best", "all"), verbose = TRUE, backfit = FALSE)
+        output = c("best", "all"), verbose = TRUE, backfit = FALSE,
+        linesearch = NULL)
 }
 \arguments{
   \item{X}{
@@ -99,6 +100,9 @@ parafac(X, nfac, nstart = 10, const = NULL, control = NULL,
 }
   \item{backfit}{
   Should backfitting algorithm be used for \code{\link{cmls}}?
+}
+  \item{linesearch}{
+  Should line-search acceleration be used? TBD, only works for 3-way PARAFAC with missing data for now.
 }
 }
 


### PR DESCRIPTION
Теоретически, мы могли бы вызывать `parafac_3wayna` напрямую, но это всё равно 
надо было сделать рано или поздно.

Сейчас не-`NULL` аргумент `linesearch` просто ничего не делает, если речь не идёт о 
3-мерном PARAFAC с `NA` в данных. В будущем можно аналогичным образом 
модифицировать другие варианты PARAFAC.

(Если бы Helwig изначально сделал `parafac` таким образом, каким он позже реализовал 
функцию `cpd`, у нас бы не было таких проблем.)

-- 
73,
Иван