### PR TITLE
Импортировать `stats::optimise` в пространство имён пакета

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -43,5 +43,5 @@ S3method(resign, parafac2)
 S3method(resign, sca)
 S3method(resign, tucker)
 
-importFrom("stats", "cor", "dbeta", "promax", "quantile", "reorder", "rnorm", "runif", "varimax")
+importFrom("stats", "cor", "dbeta", "optimise", "promax", "quantile", "reorder", "rnorm", "runif", "varimax")
 importFrom("utils", "txtProgressBar", "setTxtProgressBar")


### PR DESCRIPTION
Поскольку `optimise` располагается в пакете `stats`, а не `base`, для корректной работы пакета функцию нужно импортировать.